### PR TITLE
close #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dependencies {
 
     ... your other dependencies
 
-    compile 'com.eyeem.recyclerviewtools:library:0.2.0'
+    compile 'com.eyeem.recyclerviewtools:library:0.3.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
@@ -24,7 +24,7 @@ allprojects {
 }
 
 ext {
-    libraryVersion = '0.2.0'
+    libraryVersion = '0.3.0'
     compileSdkVersion = 23
     buildToolsVersion = '23.0.3'
     minSdkVersion = 15

--- a/library/src/main/java/com/eyeem/recyclerviewtools/RecyclerViewTools.java
+++ b/library/src/main/java/com/eyeem/recyclerviewtools/RecyclerViewTools.java
@@ -2,6 +2,7 @@ package com.eyeem.recyclerviewtools;
 
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
 
 /**
  * Created by budius on 06.10.15.
@@ -31,47 +32,38 @@ public class RecyclerViewTools {
    }
 
    /**
-    * Scroll immediately to the given position with zero offset
+    * Check the several possible layout manager and executes a instant scroll to position with offset.
+    * That means that `offset` is only properly applied for:
+    * - LinearLayoutManager
+    * - GridLayoutManager
+    * - StaggeredGridLayoutManager
+    * and any LayoutManager that extends them.
     *
-    * @param recyclerView To be scrolled
-    * @param position     The adapter position to scroll to
+    * @param recyclerView recycler view to execute the scroll
+    * @param position     the adapter position to scroll to
+    * @param offset       the offset in pixels from the start edge of the recycler and the itemView
     */
-   public static void scrollToPosition(RecyclerView recyclerView, int position) {
-      scrollToPosition(recyclerView, position, 0, false);
-   }
-
-   /**
-    * Scroll immediately to the given position with offset
-    *
-    * @param recyclerView To be scrolled
-    * @param position     The adapter position to scroll to
-    * @param offset       The distance (in pixels) between the start edge of the item view and start edge of the RecyclerView
-    */
-   public static void scrollToPosition(RecyclerView recyclerView, int position, int offset) {
-      scrollToPosition(recyclerView, position, offset, false);
-   }
-
-   /**
-    * Scroll the recycler view
-    *
-    * @param recyclerView To be scrolled
-    * @param position     The adapter position to scroll to
-    * @param offset       The distance (in pixels) between the start edge of the item view and start edge of the RecyclerView
-    * @param smooth       true for smooth scroll; false to immediate scroll;
-    */
-   public static void scrollToPosition(RecyclerView recyclerView, int position, int offset, boolean smooth) {
-
-      if (smooth) {
-         recyclerView.smoothScrollToPosition(position);
-         return;
-      }
-
-      RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
-      if (layoutManager instanceof LinearLayoutManager) {
-         LinearLayoutManager llm = (LinearLayoutManager) layoutManager;
-         llm.scrollToPositionWithOffset(position, offset);
+   public static void scrollToPositionWithOffset(RecyclerView recyclerView, int position, int offset) {
+      RecyclerView.LayoutManager lm = recyclerView.getLayoutManager();
+      if (lm instanceof LinearLayoutManager) { // GridLayoutManager extends LinearLayoutManager
+         ((LinearLayoutManager) lm).scrollToPositionWithOffset(position, offset);
+      } else if (lm instanceof StaggeredGridLayoutManager) {
+         ((StaggeredGridLayoutManager) lm).scrollToPositionWithOffset(position, offset);
       } else {
          recyclerView.scrollToPosition(position);
       }
    }
+
+   /**
+    * Currently this simply calls recyclerView.smoothScrollToPosition(position);
+    * But the API is already available and in the near future we'll try to code the `offset`
+    *
+    * @param recyclerView
+    * @param position
+    * @param offset
+    */
+   public static void smoothScrollToPositionWithOffset(RecyclerView recyclerView, int position, int offset) {
+      recyclerView.smoothScrollToPosition(position);
+   }
+
 }


### PR DESCRIPTION
this breaks compatibility with previous  static methods.
the reason is that previous were unreliable.
due to the possibilitites it could scroll immediate, it could be offset, etc.

now there're two: one is guarantee to be smooth, and the other guarantee immediate.
Even if not all cases are covered due to Recycler API limitations,
at least the timing behavior is deterministic.
